### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete regular expression for hostnames

### DIFF
--- a/google/genai/_replay_api_client.py
+++ b/google/genai/_replay_api_client.py
@@ -134,7 +134,7 @@ def _redact_request_url(url: str) -> str:
       result,
   )
   result = re.sub(
-      r'.*aiplatform.googleapis.com/[^/]+/',
+      r'.*aiplatform\.googleapis\.com/[^/]+/',
       '{VERTEX_URL_PREFIX}/',
       result,
   )


### PR DESCRIPTION
Potential fix for [https://github.com/Marcoook/python-genaiy/security/code-scanning/2](https://github.com/Marcoook/python-genaiy/security/code-scanning/2)

To fix the problem, escape the period in the regular expression on line 137 so that it matches a literal `.` rather than any character. Change `.*aiplatform.googleapis.com/[^/]+/` to `.*aiplatform\.googleapis\.com/[^/]+/`. This ensures only URLs with the exact hostname `aiplatform.googleapis.com` are redacted and the regular expression does not match unintended hosts. Only line 137 in function `_redact_request_url` needs changing; minimal changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
